### PR TITLE
Fix analytics chart date error

### DIFF
--- a/assets/js/components/wp-dashboard/WPDashboardUniqueVisitorsChartGA4.js
+++ b/assets/js/components/wp-dashboard/WPDashboardUniqueVisitorsChartGA4.js
@@ -28,6 +28,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { useSelect, useInViewSelect } from 'googlesitekit-data';
+import { stringToDate } from '../../util';
 import { CORE_UI } from '../../googlesitekit/datastore/ui/constants';
 import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
 import {
@@ -140,7 +141,7 @@ export default function WPDashboardUniqueVisitorsChartGA4( props ) {
 		);
 
 	if ( isZeroChart ) {
-		options.hAxis.ticks = [ refDate ];
+		options.hAxis.ticks = [ stringToDate( refDate ) ];
 	}
 
 	return (


### PR DESCRIPTION
## Summary

Addresses issue:

- #

Fixes an error on the Analytics dashboard's "Unique visitors..." chart when a site has zero traffic. Previously, the chart's `hAxis.ticks` property was being supplied with a date string (`YYYY-MM-DD`) instead of a `Date` object, causing a type error.

## Relevant technical choices

The `stringToDate` utility is now used to convert the `refDate` string into a `Date` object before it is assigned to `options.hAxis.ticks`. This ensures the chart receives the expected data type, resolving the error and allowing the chart to render correctly even with no visitor data.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-d15a51e9-7d72-4c0a-8d03-98312aa1970b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d15a51e9-7d72-4c0a-8d03-98312aa1970b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

